### PR TITLE
add missing options to stylesheet_link/javascript_include tag helpers

### DIFF
--- a/app/views/layout.rb
+++ b/app/views/layout.rb
@@ -16,17 +16,17 @@ module Views
           csrf_meta_tags
           meta name: "viewport", content: "width=device-width,initial-scale=1"
           title { "#{@title} - Goblin Grinder" }
-          stylesheet_link_tag "application"
-          javascript_include_tag "application"
+          stylesheet_link_tag "application", "data-turbo-track": "reload"
+          javascript_include_tag "application", "data-turbo-track": "reload", defer: true 
         end
 
         body do
           button(
             type: "button",
             class: "btn btn-lg btn-danger",
-            "data-bs-toggle" => "popover",
+            data_bs_toggle: "popover",
             title: "Popover title",
-            "data-bs-content" => "Amazing content, right ?"
+            data_bs_content: "Amazing content, right ?"
           ) do
             "Click to toggle popover"
           end


### PR DESCRIPTION
This PR adds the missing pieces to allow the JavaScript from Bootstrap to function. It was actually something minor but very easy to miss. See the screenshot for how I figured it out:
![CleanShot 2022-11-17 at 17 04 41@2x](https://user-images.githubusercontent.com/54157657/202579625-390b00b7-5c95-4025-873c-c2d1636f4213.png)

After adding the following:
![CleanShot 2022-11-17 at 17 13 53@2x](https://user-images.githubusercontent.com/54157657/202579995-00c7c048-1b0d-4272-8a83-c60a0a91bc8b.png)

We now see that...
![CleanShot 2022-11-17 at 17 11 55@2x](https://user-images.githubusercontent.com/54157657/202579808-6cd55056-b8b7-4217-980a-99d9b09b0dc5.png)
